### PR TITLE
/pocketmine:help and /pocketmine:? show pocketmine's help

### DIFF
--- a/src/HelpModifier/Main.php
+++ b/src/HelpModifier/Main.php
@@ -32,7 +32,7 @@
 
       $player = $event->getPlayer();
 
-      if($command[0] === "/help" or $command[0] === "/?") {
+      if($command[0] === "/help" or $command[0] === "/?" or $command[0] === "/pocketmine:help" or $command[0] === "/pocketmine:?") {
 
           $page_one_messages = $this->cfg->get("page_1");
 


### PR DESCRIPTION
This PR fix the bug that shows the pocketmine's help by doing /pocketmine:help or /pocketmine:?
